### PR TITLE
Load ELF binaries with libelfmaster instead of libbfd

### DIFF
--- a/ch4/inc/loader.cpp
+++ b/ch4/inc/loader.cpp
@@ -20,7 +20,20 @@ static int load_sections_lem(elfobj_t &obj, Binary *bin);
 int
 load_binary(std::string &fname, Binary *bin, Binary::BinaryType type)
 {
-  return load_binary_bfd(fname, bin, type);
+  switch(type) {
+  case Binary::BIN_TYPE_AUTO:
+  case Binary::BIN_TYPE_ELF: {
+    // Try with libelfmaster first, then fall back to BFD
+    const int ret = load_binary_lem(fname, bin);
+    if(ret == 0 || type == Binary::BIN_TYPE_ELF) {
+      return ret;
+    }
+  }
+
+  case Binary::BIN_TYPE_PE:
+  default:
+    return load_binary_bfd(fname, bin, type);
+  }
 }
 
 void


### PR DESCRIPTION
This PR updates the PBA example loader code to use [libelfmaster](https://github.com/elfmaster/libelfmaster) instead of libbfd when loading ELF binaries.